### PR TITLE
Jinja2 refactor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@
 # The email address is not required for organizations.
 
 Google Inc.
+Psycle Interactive Ltd

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@
 #
 # Names should be added to this file as:
 #     Name <email address>
+Justin Grayston justin.grayston@psycle.com


### PR DESCRIPTION
Currently a new Jinja2 environment is created on each request in BaseHandler based on the settings in constants. Under load this can lead to increased latency per request. The BaseHandler has been slightly refactored to make user of webapp2_extras.jinja2 using the get_jinja2 method. This caches the Jinja2 environment in the app registry and significantly improves performance under load.

A factory method is used, so that control of the config is still controlled by the constants and BaseHandler rather than using the webapp2 config which is how you might see it implemented else where. 

Whilst a cached Jinja2 environment can be added to post instantiation, for example adding globals and extensions, keeping the config in BaseHandler should keep it silently in place and is probably a good compromise between sensible/safe settings and performance.

Also the factory method should take priority should someone add webapp2_extras.jinja2 to the webapp config, overriding it. 
