### PR TITLE
Fix run_tests.py to account for appengine_config.py

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -17,6 +17,13 @@ def main(sdk_path, test_path, third_party_path=None):
   dev_appserver.fix_sys_path()
   if third_party_path:
     sys.path.insert(0, third_party_path)
+
+  try:
+    import appengine_config
+    (appengine_config)
+  except ImportError:
+    print "Note: unable to import appengine_config."
+        
   suite = unittest2.loader.TestLoader().discover(test_path,
                                                  pattern='*_test.py')
   unittest2.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This makes sure the test runner imports vendored third party libraries when running the test suite. 

Addresses https://github.com/google/gae-secure-scaffold-python/issues/21
