### PR TITLE
Added strict CSP support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
         compilerFile: [process.env.HOME,
                       'bin', 'google_closure', 'compiler.jar'].join('/'),
         compilerOpts: {
-          compilation_level: grunt.option('dev', false) ?
+          compilation_level: grunt.option('dev') ?
             'SIMPLE_OPTIMIZATIONS' : 'ADVANCED_OPTIMIZATIONS'
         },
         namespaces: 'app',

--- a/src/base/constants.py
+++ b/src/base/constants.py
@@ -19,6 +19,9 @@ import os
 def _IsDevAppServer():
   return os.environ.get('SERVER_SOFTWARE', '').startswith('Development')
 
+# CSP Nonce length
+NONCE_LENGTH = 10
+
 # webapp2 application configuration constants.
 # template
 (DJANGO, JINJA2) = range(0, 2)
@@ -33,8 +36,9 @@ X_FRAME_OPTIONS_VALUES = {DENY: 'DENY', SAMEORIGIN: 'SAMEORIGIN'}
 # hsts_policy
 DEFAULT_HSTS_POLICY = {'max_age': 2592000, 'includeSubdomains': True}
 
-# csp_policy
-DEFAULT_CSP_POLICY = {'default-src': '\'self\''}
+# placeholder for the CSP nonce. 'nonce_value' is replaced for every response
+# in base/handers.py with a random nonce value.
+CSP_NONCE_PLACEHOLDER_FORMAT = '\'nonce-%(nonce_value)s\' '
 
 # IS_DEV_APPSERVER is primarily used for decisions that rely on whether or
 # not the application is currently serving over HTTPS (dev_appserver does
@@ -44,3 +48,19 @@ IS_DEV_APPSERVER = _IsDevAppServer()
 DEBUG = IS_DEV_APPSERVER
 
 TEMPLATE_DIR = os.path.sep.join([os.path.dirname(__file__), '..', 'templates'])
+
+# csp_policy
+DEFAULT_CSP_POLICY = {
+    # Disallow Flash, etc.
+    'object-src': '\'none\'',
+    # Strict CSP with fallbacks for browsers not supporting CSP v3.
+    'script-src': CSP_NONCE_PLACEHOLDER_FORMAT +
+                  # Propagate trust to dynamically created scripts.
+                  '\'strict-dynamic\' '
+                  # Fallback. Ignored in presence of a nonce
+                  '\'unsafe-inline\' '
+                  # Fallback. Ignored in presence of strict-dynamic.
+                  'https: http:',
+    'report-uri': '/csp',
+    'reportOnly': DEBUG,
+}

--- a/src/examples/example_handlers.py
+++ b/src/examples/example_handlers.py
@@ -89,3 +89,19 @@ class XssiHandler(handlers.BaseHandler):
 
   def post(self):
     self.get()
+
+
+class CspHandler(handlers.BaseHandler):
+
+  def get(self):
+    # Test for jinja extension
+    extensions = self.get_jinja2_config()['environment_args']['extensions']
+    autoescape_ext = 'jinja2.ext.autoescape' in extensions
+
+    if not constants.IS_DEV_APPSERVER:
+      self.render('debug_only.tpl')
+      return
+    self.render('csp.tpl')
+
+  def post(self):
+    self.get()

--- a/static/index.html
+++ b/static/index.html
@@ -14,6 +14,7 @@
     <li><a href="/examples/xss">Cross-Site Scripting (XSS) protection</a></li>
     <li><a href="/examples/xssi">Cross-Site Script Inclusion (XSSI) protection</a></li>
     <li><a href="/examples/xsrf">Cross-Site Request Forgery (XSRF) protection</a></li>
+    <li><a href="/examples/csp">Content Security Policy (CSP)</a></li>
   </ul>
   </body>
 </html>

--- a/templates/csp.tpl
+++ b/templates/csp.tpl
@@ -1,0 +1,57 @@
+{% extends "base.tpl" %}
+{% block title %}
+  Content Security Policy
+{% endblock %}
+{% block content %}
+<h1>Content Security Policy</h1>
+<p>CSP is a mechanism designed to make applications more secure against common
+Web vulnerabilities, particularly XSS.<br>
+It is enabled by delivering a policy in the <code>Content-Security-Policy</code> HTTP response header.
+</p>
+
+<p>A production-quality strict policy appropriate for many products is:<br>
+<code>
+Content-Security-Policy:
+  object-src 'none';
+  script-src 'nonce-{random}' 'strict-dynamic' 'unsafe-inline' 'unsafe-eval' https: http:;
+</code>
+</p>
+
+<p>
+When such a policy is set, modern browsers will execute only those scripts whose
+nonce attribute matches the value set in the policy header, as well as scripts
+dynamically added to the page by scripts with the proper nonce.<br>Older browsers,
+which don't support the CSP3 standard, will ignore the <code>nonce-*</code> and
+<code>'strict-dynamic'</code> keywords and fall back to
+[<code>script-src 'unsafe-inline' https: http:</code>] which will not provide
+protection against XSS vulnerabilities, but will allow the application to
+function properly.
+</p>
+
+<h2>Adopting a strict policy</h2>
+<p>
+To use a strict CSP policy, most applications will need to make the following changes:
+<br>
+<ul>
+  <li>Add a nonce attribute to all <code>&lt;script&gt;</code> elements. Some template systems can do this automatically.
+    <br>E.g. in Jinja:
+    {% raw %}
+    <code>&lt;script&gt; nonce="{{_csp_nonce}}" src="..."&gt;&lt;/script&gt;</code>
+    {% endraw %}
+
+  <li>Refactor any markup with inline event handlers (<code>onclick</code>, etc.) and <code>javascript:</code> URIs (details).
+  <li>For every page load, generate a new nonce, pass it the to the template system, and use the same value in the <code>Content-Security-Policy</code> response header.
+</ul>
+</p>
+
+<h2>Example of a nonced script that dynamically adds child scripts</h2>
+<!--
+     Twitter timeline dynamically creates child element which are allowed
+     to execute because of 'strict-dynamic'.
+     The widget shows a manually curated twitter collection of relevant
+     strict-csp posts. Will be replaced with better documentation soon.
+-->
+<a class="twitter-timeline" data-width="800" data-height="600" data-dnt="true" data-partner="tweetdeck" href="https://twitter.com/we1x/timelines/765840589183213568">Strict CSP</a>
+<script nonce="{{_csp_nonce}}" async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+{% endblock %}


### PR DESCRIPTION
Update GAE Secure Scaffold to use a strict CSP based on nonces and 'strict-dynamic', because whitelist based CSPs can usually be bypassed. 
Check out these slides to learn more about whitelist bypasses and strict CSP [goo.gl/PIR98R](https://goo.gl/PIR98R)
Spec: [https://www.w3.org/TR/CSP3/#strict-dynamic-usage](https://www.w3.org/TR/CSP3/#strict-dynamic-usage)
