### PR TITLE
Fixes an issue where '-dev' was always being added to versionString

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,8 +136,8 @@ module.exports = function(grunt) {
             grunt.log.writeln('git status error: ' + result);
             done(false);
           }
-          if (String(result).indexOf('\nnothing to commit, working ' +
-                'directory clean') == -1) {
+          var pattern = /nothing to commit, working (directory|tree) clean/i;
+          if (!pattern.test(String(result))) {
             uncommitedChanges = true;
           }
           grunt.util.spawn(


### PR DESCRIPTION
Fixes an issue where '-dev' was always being added to versionString when
deploying to AppEngine on a machine using Git v2.9.1 or higher.

Details:
From Git v2.9.1, the messaging when there are no uncommitted changes has changed.
See: https://github.com/git/git/blob/e0c1ceafc5bece92d35773a75fff59497e1d9bd5/Documentation/RelNotes/2.9.1.txt#L53

The old message was: "nothing to commit, working directory clean"
The new message is: "nothing to commit, working tree clean"

The PR includes a fix so that both the old and new message will be tested
against, and the -dev will be added as intended.
