### PR TITLE
Adding Soy to Py support to Scaffold

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
     },
 
     closureSoys: {
-      all: {
+      js: {
         src: ['templates', 'soy', '**', '*.soy'].join('/'),
         soyToJsJarPath: [process.env.HOME, 'bin', 'google_closure_templates',
                          'SoyToJsSrcCompiler.jar'].join('/'),
@@ -53,7 +53,18 @@ module.exports = function(grunt) {
           // goog.provide and goog.require statements are added.
           shouldProvideRequireSoyNamespaces: false
         }
+      },
+      py: {
+         src: ['templates', 'soy', '**', '*.soy'].join('/'),
+        soyToJsJarPath: [process.env.HOME, 'bin', 'google_closure_templates',
+                         'SoyToPySrcCompiler.jar'].join('/'),
+        outputPathFormat: [targetDirectory, 'generated', '{INPUT_FILE_NAME_NO_EXT}.py'].join('/'),
+        options: {
+          // This points to the package - targetDirectory/generated/soyPython
+          runtimePath:'soyPython',
+        }
       }
+      
     },
 
     copy: {
@@ -68,6 +79,12 @@ module.exports = function(grunt) {
         dest: [targetDirectory, 'static', ''].join('/'),
         expand: true,
         src: 'soyutils.js'
+      },
+       soy_python: {
+        cwd: [process.env.HOME, 'bin', 'google_closure_templates','closure-templates','python'].join('/'),
+        dest: [targetDirectory,'generated','soyPython',''].join('/'),
+        expand: true,
+        src: '**'
       },
       static: {
         cwd: 'static',
@@ -151,7 +168,8 @@ module.exports = function(grunt) {
   grunt.registerTask('default',
       ['copy:source', 'copy:static', 'copy:templates',
        'copy:third_party_js', 'copy:third_party_py',
-      grunt.config.get('build.use_closure_templates') ? 'closureSoys' : 'nop',
+      grunt.config.get('build.use_closure_templates') ? 'closureSoys:js' : 'nop',
+      grunt.config.get('build.use_closure_py_templates') ? 'closureSoys:py' : 'nop',
       grunt.config.get('build.use_closure_templates') ? 'copy:soyutils' : 'nop',
       grunt.config.get('build.use_closure') ? 'closureBuilder' : 'nop',
       'yaml']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,6 @@ module.exports = function(grunt) {
           runtimePath:'soyPython',
         }
       }
-      
     },
 
     copy: {

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ An alternative to the Grunt build is provided via the `util.sh` shell script.
 1.  `git clone https://github.com/google/closure-templates.git`
 1.  `cd closure-templates && mvn`
 1.  After Maven completes building the files, `touch python/__init__.py`
-1.  `cd target
+1.  `cd target`
 1.  `rename 's/ *soy-[0-9]{4}-?[0-9]{2}-?[0-9]{2}-//' ./*.jar`
 1.  `cp SoyToPySrcCompiler.jar ../../`
 1.  `popd`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ An alternative to the Grunt build is provided via the `util.sh` shell script.
 1.  `unzip closure-templates-for-javascript-latest.zip`
 1.  `git clone https://github.com/google/closure-templates.git`
 1.  `cd closure-templates && mvn`
-1.  After Maven completes building the files, `touch python/__init__.py
+1.  After Maven completes building the files, `touch python/__init__.py`
 1.  `cd target
 1.  `rename 's/ *soy-[0-9]{4}-?[0-9]{2}-?[0-9]{2}-//' ./*.jar`
 1.  `cp SoyToPySrcCompiler.jar ../../`

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ An alternative to the Grunt build is provided via the `util.sh` shell script.
 1.  `mkdir google_closure_templates; cd google_closure_templates`
 1.  `curl -O https://dl.google.com/closure-templates/closure-templates-for-javascript-latest.zip`
 1.  `unzip closure-templates-for-javascript-latest.zip`
+1.  `git clone https://github.com/google/closure-templates.git`
+1.  `cd closure-templates && mvn`
+1.  After Maven completes building the files, `touch python/__init__.py
+1.  `cd target
+1.  `rename 's/ *soy-[0-9]{4}-?[0-9]{2}-?[0-9]{2}-//' ./*.jar`
+1.  `cp SoyToPySrcCompiler.jar ../../`
 1.  `popd`
 
 To install dependencies for unit testing:

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "appid": "scaffold",
   "use_closure": true,
-  "use_closure_templates": true
+  "use_closure_templates": true,
+  "use_closure_py_templates": true
 }
 


### PR DESCRIPTION
Config.json - can toggle on/off Python support
Gruntfile.js - new config for SoyToPy conversion using closure-soy and copy task to move the python runtime files required by the generated files
README - compiling the SoyToPySrcCompiler.jar and moving it to the right directory, creating a __init__.py file to make the python files a package