### PR TITLE
Update variable names and comments to fit Google's style guide

### DIFF
--- a/src/base/api_fixer.py
+++ b/src/base/api_fixer.py
@@ -89,8 +89,8 @@ ReplaceDefaultArgument(json.dumps, 'cls', _JsonEncoderForHtml)
 
 
 # Pickle.  See http://www.cs.jhu.edu/~s/musings/pickle.html for more info.
-# Whitelist of module name => (module, [list of safe names])
-_PICKLE_CLASS_WHITELIST = { '__builtin__': (__builtin__,
+# Map of safe module name => (module, [list of safe names])
+_PICKLE_CLASS_SAFE_NAMES = { '__builtin__': (__builtin__,
                                             ['basestring',
                                              'bool',
                                              'buffer',
@@ -117,7 +117,7 @@ _PICKLE_CLASS_WHITELIST = { '__builtin__': (__builtin__,
 class RestrictedUnpickler(pickle.Unpickler):
 
   def find_class(self, module_name, name):
-    (module, safe_names) = _PICKLE_CLASS_WHITELIST.get(module_name, (None, []))
+    (module, safe_names) = _PICKLE_CLASS_SAFE_NAMES.get(module_name, (None, []))
     if name in safe_names:
       return getattr(module, name)
     raise ApiSecurityException('%s.%s forbidden in unpickling' % (module, name))
@@ -178,4 +178,3 @@ urlfetch.make_fetch_call = _HttpUrlLoggingWrapper(urlfetch.make_fetch_call)
 sessions.default_config['cookie_args']['secure'] = (not
                                                     constants.IS_DEV_APPSERVER)
 sessions.default_config['cookie_args']['httponly'] = True
-

--- a/src/base/handlers.py
+++ b/src/base/handlers.py
@@ -106,7 +106,7 @@ _RESTRICTED_FUNCTION_LIST = [
 # functions in the _RESTRICTED_FUNCTION_LIST.  Note that there is no
 # package/module specified, so it is possible to bypass this check through
 # clever (or malicious) naming.
-_RESTRICTED_FUNCTION_CLASS_WHITELIST = [
+_RESTRICTED_FUNCTION_TRUSTED_CLASSES = [
     'BaseHandler',
     'BaseAjaxHandler',
     'BaseCronHandler',
@@ -142,13 +142,13 @@ class _HandlerMeta(abc.ABCMeta):
   'final' are not declared in subclasses. This is because we provide a
   default implementation which enforces various security related functionality.
 
-  Class names that can bypass this whitelist are listed in
-  _RESTRICTED_FUNCTION_CLASS_WHITELIST.  Restricted methods are listed in
+  Class names that can bypass this check are listed in
+  _RESTRICTED_FUNCTION_TRUSTED_CLASSES.  Restricted methods are listed in
   _RESTRICTED_FUNCTION_LIST.
   """
 
   def __new__(mcs, name, bases, dct):
-    if name not in _RESTRICTED_FUNCTION_CLASS_WHITELIST:
+    if name not in _RESTRICTED_FUNCTION_TRUSTED_CLASSES:
       for func in _RESTRICTED_FUNCTION_LIST:
         if func in dct:
           raise SecurityError('%s attempts to override restricted method %s' %


### PR DESCRIPTION
Use of "whitelist" is discouraged by Google's style guide.

https://developers.google.com/style/word-list#blacklist

These changes affect a couple of code comments and variable names beginning with an underscore, so we can be pretty confident that consumers of this library won't break.